### PR TITLE
:sparkles: feat(EST-66): Aula 2: Modo Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ http://localhost:8080/
 
 * [Alura | Curso de GPT e Java: desenvolva um Chatbot com IA](https://cursos.alura.com.br/course/gpt-java-desenvolva-chatbot-ia)
 * [OpenAI | Streaming](https://platform.openai.com/docs/api-reference/streaming)
+* [OpenAI | Assistants](https://platform.openai.com/docs/assistants/overview)

--- a/src/main/java/br/com/alura/chatbot/domain/service/ChatbotService.java
+++ b/src/main/java/br/com/alura/chatbot/domain/service/ChatbotService.java
@@ -2,20 +2,18 @@ package br.com.alura.chatbot.domain.service;
 
 import br.com.alura.chatbot.openai.DadosRequisicaoChatCompletion;
 import br.com.alura.chatbot.openai.OpenAIClient;
-import com.theokanning.openai.completion.chat.ChatCompletionChunk;
-import io.reactivex.Flowable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ChatbotService {
 
-    private OpenAIClient openAIClient;
+    private final OpenAIClient openAIClient;
 
     public ChatbotService(OpenAIClient openAIClient) {
         this.openAIClient = openAIClient;
     }
 
-    public Flowable<ChatCompletionChunk> responderPergunta(String pergunta) {
+    public String responderPergunta(String pergunta) {
         var promptSistema = "Você é um chatbot de atendimento a clientes de um ecommerce e deve responder apenas perguntas relacionadas com o ecommerce";
         var dados = new DadosRequisicaoChatCompletion(promptSistema, pergunta);
         return openAIClient.enviarRequisicaoChatCompletion(dados);

--- a/src/main/java/br/com/alura/chatbot/openai/OpenAIClient.java
+++ b/src/main/java/br/com/alura/chatbot/openai/OpenAIClient.java
@@ -1,75 +1,89 @@
 package br.com.alura.chatbot.openai;
 
-import com.theokanning.openai.OpenAiHttpException;
-import com.theokanning.openai.completion.chat.ChatCompletionChunk;
-import com.theokanning.openai.completion.chat.ChatCompletionRequest;
-import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.theokanning.openai.messages.Message;
+import com.theokanning.openai.messages.MessageRequest;
+import com.theokanning.openai.runs.RunCreateRequest;
 import com.theokanning.openai.service.OpenAiService;
-import io.reactivex.Flowable;
+import com.theokanning.openai.threads.ThreadRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Comparator;
 
 @Component
 public class OpenAIClient {
 
     private final String opeanAIApiKey;
+    private final String assistantId;
     private final OpenAiService openAiService;
 
-    public OpenAIClient(@Value("${app.openai.api.key}") String opeanAIApiKey) {
+    private String threadId;
+
+    public OpenAIClient(@Value("${app.openai.api.key}") String opeanAIApiKey,
+                        @Value("${app.openai.assistant.id}") String assistantId) {
         this.opeanAIApiKey = opeanAIApiKey;
         this.openAiService = new OpenAiService(opeanAIApiKey, Duration.ofSeconds(60));
+        this.assistantId = assistantId;
     }
 
     /**
-     * O streaming de mensagens da API da OpenAI é uma característica avançada que permite a comunicação bidirecional e
-     * contínua entre o cliente e o servidor.
-     * Essa funcionalidade é especialmente útil para aplicações que requerem troca de dados em tempo real ou
-     * para a manutenção de uma conversa persistente em cenários que envolvem modelos de linguagem,
-     * como chatbots ou assistentes virtuais.
+     * O modo Assistant da OpenAI, embora represente um avanço significativo em termos de inteligência artificial e ofereça múltiplas aplicações, enfrenta algumas limitações. Com a ambição de melhorar continuamente o serviço, a OpenAI está ciente das restrições atuais e planeja expandir as capacidades do Assistant com atualizações futuras.
+     * Abaixo, detalhamos algumas das limitações conhecidas na versão beta do modo Assistant da OpenAI:
+     * 1. Suporte para saída em tempo real (streaming output): atualmente, o Assistant não oferece suporte para saída contínua de dados, o que inclui mensagens e etapas de execução em tempo real, comumente conhecidas como "streaming". Essa funcionalidade é crucial para aplicações que necessitam de interações constantes e atualizações imediatas.
+     * 2. Suporte para notificações: outra restrição é a inexistência de um mecanismo de notificações que permita compartilhar atualizações sobre o status de objetos sem recorrer a pesquisas frequentes ou polling. Isso significa que, no momento, para obter informações atualizadas, é necessário fazer novas solicitações repetidamente, o que pode ser ineficiente.
+     * 3. Integração com DALL·E ou funcionalidades de navegação (browsing): o Assistant ainda não tem funcionalidades para integrar o DALL·E, o sistema da OpenAI que gera imagens a partir de descrições textuais, nem para realizar atividades de navegação pela internet. Isso limita as possibilidades de interação com conteúdos visuais e de busca de informações.
+     * 4. Criação de mensagens de usuário com imagens: a interação atual não permite que usuários criem mensagens integradas com imagens, o que restringe a capacidade de comunicação a textos puros, sem a riqueza e o contexto que as imagens podem proporcionar.
      *
      * @param dados prompts
      * @return resposta
      */
-    public Flowable<ChatCompletionChunk> enviarRequisicaoChatCompletion(DadosRequisicaoChatCompletion dados) {
-        var request = ChatCompletionRequest
+    public String enviarRequisicaoChatCompletion(DadosRequisicaoChatCompletion dados) {
+        var messageRequest = MessageRequest
                 .builder()
-                .model("gpt-4-1106-preview")
-                .messages(Arrays.asList(
-                        new ChatMessage(
-                                ChatMessageRole.SYSTEM.value(),
-                                dados.promptSistema()),
-                        new ChatMessage(
-                                ChatMessageRole.USER.value(),
-                                dados.promptUsuario())))
-                .stream(true)
+                .role(ChatMessageRole.USER.value())
+                .content(dados.promptUsuario())
                 .build();
 
-        var segundosParaProximaTentiva = 5;
-        var tentativas = 0;
-        while (tentativas++ != 5) {
-            try {
-                return openAiService
-                        .streamChatCompletion(request);
-            } catch (OpenAiHttpException ex) {
-                var errorCode = ex.statusCode;
-                switch (errorCode) {
-                    case 401 -> throw new RuntimeException("Erro com a chave da API!", ex);
-                    case 429, 500, 503 -> {
-                        try {
-                            Thread.sleep(1000 * segundosParaProximaTentiva);
-                            segundosParaProximaTentiva *= 2;
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
-                }
-            }
+        if (this.threadId == null) {
+            var threadRequest = ThreadRequest
+                    .builder()
+                    .messages(Arrays.asList(messageRequest))
+                    .build();
+
+            var thread = openAiService.createThread(threadRequest);
+            this.threadId = thread.getId();
+        } else {
+            openAiService.createMessage(this.threadId, messageRequest);
         }
-        throw new RuntimeException("API Fora do ar! Tentativas finalizadas sem sucesso!");
+
+        //código omitido
+
+        var runRequest = RunCreateRequest
+                .builder()
+                .assistantId(assistantId)
+                .build();
+        var run = openAiService.createRun(threadId, runRequest);
+
+        try {
+            while (!run.getStatus().equalsIgnoreCase("completed")) {
+                Thread.sleep(1000 * 10); //10 segundos
+                run = openAiService.retrieveRun(threadId, run.getId());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        var mensagens = openAiService.listMessages(threadId);
+
+        return mensagens
+                .getData()
+                .stream()
+                .max(Comparator.comparingInt(Message::getCreatedAt))
+                .orElseThrow()
+                .getContent().get(0).getText().getValue();
     }
 
 }

--- a/src/main/java/br/com/alura/chatbot/web/controller/ChatController.java
+++ b/src/main/java/br/com/alura/chatbot/web/controller/ChatController.java
@@ -4,7 +4,6 @@ import br.com.alura.chatbot.domain.service.ChatbotService;
 import br.com.alura.chatbot.web.dto.PerguntaDto;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 
 @Controller
 @RequestMapping({"/", "chat"})
@@ -12,7 +11,7 @@ public class ChatController {
 
     private static final String PAGINA_CHAT = "chat";
 
-    private ChatbotService chatbotService;
+    private final ChatbotService chatbotService;
 
     public ChatController(ChatbotService chatbotService) {
         this.chatbotService = chatbotService;
@@ -25,21 +24,8 @@ public class ChatController {
 
     @PostMapping
     @ResponseBody
-    public ResponseBodyEmitter responderPergunta(@RequestBody PerguntaDto perguntaDto) {
-        var fluxoResposta = chatbotService.responderPergunta(perguntaDto.pergunta());
-        var emitter = new ResponseBodyEmitter();
-
-        fluxoResposta.subscribe(chunk -> {
-                    var token = chunk.getChoices().get(0).getMessage().getContent();
-                    if (token != null) {
-                        emitter.send(token);
-                    }
-                },
-                emitter::completeWithError,
-                emitter::complete
-        );
-
-        return emitter;
+    public String responderPergunta(@RequestBody PerguntaDto perguntaDto) {
+        return chatbotService.responderPergunta(perguntaDto.pergunta());
     }
 
     @GetMapping("limpar")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=alura-openai-chatbot-java
 app.openai.api.key=${OPENAI_API_KEY}
+app.openai.assistant.id=${OPENAI_ASSISTANT_ID}


### PR DESCRIPTION
Nesta aula, você aprendeu:

- Que o modo de chat da OpenAI não armazena o histórico de mensagens;
- Que a OpenAI disponibiliza o modo Assistant (assistente), que deve ser utilizado quando desejamos manter o histórico de mensagens;
- Como funciona o modo Assistant, seus objetos e fluxo de trabalho para gerar respostas;
- A criar, configurar e testar o modo Assistant via Playground;
- A adaptar o código da aplicação Chatbot para utilizar o modo Assistant, gerando respostas que levam em consideração todas as mensagens anteriores.